### PR TITLE
Backend command line option

### DIFF
--- a/.builds/ci.yml
+++ b/.builds/ci.yml
@@ -8,4 +8,4 @@ tasks:
   - build: |
       cargo build
       cargo test
-      cargo clippy --all-targets --all-features -- -D warnings
+      cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Feature flags for backends (`backend_c`, etc.) have been replaced by `--target` (`-t`) command-line option:
+
+  ```sh
+  sb -t c run examples/hello_world.sb
+  ```
+
 ## v0.5.1 (2021-02-25)
 
 Sabre is now Antimony!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,9 @@ edition = "2018"
 name = "sb"
 path = "src/main.rs"
 
-[features]
-backend_c = []
-backend_node = []
-backend_llvm = ["inkwell"]
-
-# To change, use the --featues flag:
-# cargo run --no-default-features --features backend_llvm
-default = ["backend_node"]
-
 [dependencies]
 structopt = "0.3.21"
 rust-embed = "5.7.0"
 tempfile = "3.1.0"
-inkwell = { version = "0.1.0-beta.2", features = ["llvm10-0"], optional = true }
+inkwell = { version = "0.1.0-beta.2", features = ["llvm10-0"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,12 @@ edition = "2018"
 name = "sb"
 path = "src/main.rs"
 
+[features]
+llvm = ["inkwell"]
+
 [dependencies]
 structopt = "0.3.21"
 rust-embed = "5.7.0"
 tempfile = "3.1.0"
-inkwell = { version = "0.1.0-beta.2", features = ["llvm10-0"] }
+inkwell = { version = "0.1.0-beta.2", features = ["llvm10-0"], optional = true }
 

--- a/docs/developers/backends.md
+++ b/docs/developers/backends.md
@@ -5,7 +5,7 @@ Antimony currently implements a JavaScript backend, but a C backend is in develo
 Backend can be specified when running on building with `--target` (`-t`) option, default is `js`:
 
 ```sh
-sb -t llvm build in.sb --out-file out
+sb -t c build in.sb --out-file out
 ```
 
 ## Available Backends
@@ -15,3 +15,9 @@ sb -t llvm build in.sb --out-file out
 | Node.js         | `js`           | mostly stable    |
 | LLVM            | `llvm`         | unstable         |
 | C               | `c`            | unstable         |
+
+LLVM also requires to enable `llvm` feature when building:
+
+```sh
+cargo build --features llvm
+```

--- a/docs/developers/backends.md
+++ b/docs/developers/backends.md
@@ -1,25 +1,17 @@
 # Backends
 
 Antimony currently implements a JavaScript backend, but a C backend is in development. WASM, ARM and x86 are planned.
-The backend can be specified in the `Cargo.toml` file in the root of the project:
 
-```toml
-[features]
-...
+Backend can be specified when running on building with `--target` (`-t`) option, default is `js`:
 
-default = ["backend_c"]
-```
-
-If you're working on an unstable backend, you can override the backend using the `--features --no-default-features` flag of the cargo CLI:
-
-```
-cargo run --no-default-features --features backend_llvm ...
+```sh
+sb -t llvm build in.sb --out-file out
 ```
 
 ## Available Backends
 
 | Target Language | Identifier     | Stability notice |
 | :-------------- | :------------- | :--------------- |
-| Node.js         | `backend_node` | mostly stable    |
-| LLVM            | `backend_llvm` | unstable         |
-| C               | `backend_c`    | unstable         |
+| Node.js         | `js`           | mostly stable    |
+| LLVM            | `llvm`         | unstable         |
+| C               | `c`            | unstable         |

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,10 +1,10 @@
 use crate::ast::Module;
 use crate::generator;
-use generator::Generator;
 use crate::lexer;
 use crate::parser;
 use crate::Lib;
 use crate::PathBuf;
+use generator::Generator;
 use std::env;
 /**
  * Copyright 2021 Garrit Franke
@@ -102,7 +102,11 @@ impl Builder {
         Ok(module)
     }
 
-    pub(crate) fn generate(&mut self, target: generator::Target, out_file: PathBuf) -> Result<(), String> {
+    pub(crate) fn generate(
+        &mut self,
+        target: generator::Target,
+        out_file: PathBuf,
+    ) -> Result<(), String> {
         let mut mod_iter = self.modules.iter();
 
         // TODO: We shouldn't clone here

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -118,7 +118,13 @@ impl Builder {
         let output = match target {
             generator::Target::JS => generator::js::JsGenerator::generate(condensed),
             generator::Target::C => generator::c::CGenerator::generate(condensed),
-            generator::Target::LLVM => generator::llvm::LLVMGenerator::generate(condensed),
+            generator::Target::LLVM => {
+                #[cfg(feature = "llvm")]
+                return generator::llvm::LLVMGenerator::generate(condensed);
+
+                #[cfg(not(feature = "llvm"))]
+                panic!("'llvm' feature should be enabled to use LLVM target");
+            }
         };
 
         let mut file = std::fs::File::create(out_file).expect("create failed");

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -116,16 +116,9 @@ impl Builder {
         }
 
         let output = match target {
-            #[cfg(feature = "backend_node")]
             generator::Target::JS => generator::js::JsGenerator::generate(condensed),
-
-            #[cfg(feature = "backend_c")]
             generator::Target::C => generator::c::CGenerator::generate(condensed),
-
-            #[cfg(feature = "backend_llvm")]
             generator::Target::LLVM => generator::llvm::LLVMGenerator::generate(condensed),
-
-            _ => panic!("No applicable backend"),
         };
 
         let mut file = std::fs::File::create(out_file).expect("create failed");

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use crate::generator;
 use crate::builder;
 use std::path::Path;
 
-pub fn build(in_file: &Path, out_file: &Path) -> Result<(), String> {
+pub fn build(target: generator::Target, in_file: &Path, out_file: &Path) -> Result<(), String> {
     let mut b = builder::Builder::new(in_file.to_path_buf());
     b.build()?;
-    b.generate(out_file.to_path_buf())
+    b.generate(target, out_file.to_path_buf())
 }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::generator;
 use crate::builder;
+use crate::generator;
 use std::path::Path;
 
 pub fn build(target: generator::Target, in_file: &Path, out_file: &Path) -> Result<(), String> {

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 use crate::command::build;
+use crate::generator::Target;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
@@ -21,14 +22,13 @@ use std::process::Command;
 use std::process::Stdio;
 use tempfile::tempdir;
 
-pub fn run(in_file: PathBuf) -> Result<(), String> {
+pub fn run(target: Target, in_file: PathBuf) -> Result<(), String> {
     let out_dir = tempdir()
         .expect("Could not create temporary file")
         .into_path();
 
     let intermediate_out_file_path = out_dir.join("intermediate.c");
-    // TODO
-    build::build(crate::generator::Target::JS, &in_file, &intermediate_out_file_path)?;
+    build::build(target, &in_file, &intermediate_out_file_path)?;
     let out_file = out_dir.join("out");
     if cfg!(feature = "backend_c") {
         Command::new("/usr/bin/cc")

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -27,7 +27,8 @@ pub fn run(in_file: PathBuf) -> Result<(), String> {
         .into_path();
 
     let intermediate_out_file_path = out_dir.join("intermediate.c");
-    build::build(&in_file, &intermediate_out_file_path)?;
+    // TODO
+    build::build(crate::generator::Target::JS, &in_file, &intermediate_out_file_path)?;
     let out_file = out_dir.join("out");
     if cfg!(feature = "backend_c") {
         Command::new("/usr/bin/cc")

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -30,46 +30,50 @@ pub fn run(target: Target, in_file: PathBuf) -> Result<(), String> {
     let intermediate_out_file_path = out_dir.join("intermediate.c");
     build::build(target, &in_file, &intermediate_out_file_path)?;
     let out_file = out_dir.join("out");
-    if cfg!(feature = "backend_c") {
-        Command::new("/usr/bin/cc")
-            .arg(&intermediate_out_file_path)
-            .arg("-o")
-            .arg(&out_file)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .expect("Could not spawn compilation process");
+    match target {
+        Target::C => {
+            Command::new("/usr/bin/cc")
+                .arg(&intermediate_out_file_path)
+                .arg("-o")
+                .arg(&out_file)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .expect("Could not spawn compilation process");
 
-        let out = Command::new(out_file)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .expect("Could not spawn run process");
+            let out = Command::new(out_file)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .expect("Could not spawn run process");
 
-        std::io::stdout()
-            .write_all(&out.stdout)
-            .expect("Could not write to stdout");
+            std::io::stdout()
+                .write_all(&out.stdout)
+                .expect("Could not write to stdout");
 
-        std::io::stderr()
-            .write_all(&out.stderr)
-            .expect("Could not write to stderr");
-    } else if cfg!(feature = "backend_node") {
-        let out = Command::new("node")
-            .arg(&intermediate_out_file_path)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .expect("Could not spawn run process");
+            std::io::stderr()
+                .write_all(&out.stderr)
+                .expect("Could not write to stderr");
+        }
+        Target::JS => {
+            let out = Command::new("node")
+                .arg(&intermediate_out_file_path)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .expect("Could not spawn run process");
 
-        std::io::stdout()
-            .write_all(&out.stdout)
-            .expect("Could not write to stdout");
+            std::io::stdout()
+                .write_all(&out.stdout)
+                .expect("Could not write to stdout");
 
-        std::io::stderr()
-            .write_all(&out.stderr)
-            .expect("Could not write to stderr");
+            std::io::stderr()
+                .write_all(&out.stderr)
+                .expect("Could not write to stderr");
 
-        process::exit(out.status.code().unwrap())
+            process::exit(out.status.code().unwrap())
+        }
+        _ => todo!(),
     }
     Ok(())
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -16,11 +16,8 @@
 use crate::ast::*;
 use std::str::FromStr;
 
-#[cfg(feature = "backend_c")]
 pub mod c;
-#[cfg(feature = "backend_node")]
 pub mod js;
-#[cfg(feature = "backend_llvm")]
 pub mod llvm;
 #[cfg(test)]
 mod tests;
@@ -40,19 +37,11 @@ impl FromStr for Target {
         let s = s.to_lowercase();
 
         match s.as_str() {
-            #[cfg(feature = "backend_c")]
             "c" => Ok(Target::C),
-
-            #[cfg(feature = "backend_node")]
             "js" => Ok(Target::JS),
-
-            #[cfg(feature = "backend_llvm")]
             "llvm" => Ok(Target::LLVM),
 
-            _ => Err(format!(
-                "no target {T} found, maybe you forgot to enable backend_{T} feature?",
-                T = s
-            )),
+            _ => Err(format!("no target {} found", s)),
         }
     }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -23,7 +23,7 @@ pub mod llvm;
 mod tests;
 pub mod x86;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Target {
     C,
     JS,

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 
 pub mod c;
 pub mod js;
+#[cfg(feature = "llvm")]
 pub mod llvm;
 #[cfg(test)]
 mod tests;

--- a/src/generator/tests/mod.rs
+++ b/src/generator/tests/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(feature = "backend_c")]
 mod c_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,9 @@ extern crate rust_embed;
 extern crate structopt;
 extern crate tempfile;
 
+use generator::Target;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use generator::Target;
 
 mod ast;
 mod builder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), String> {
     let opts = Opt::from_args();
 
     match opts.command {
-        Command::Build { in_file, out_file } => command::build::build(&in_file, &out_file)?,
+        Command::Build { in_file, out_file } => command::build::build(opts.target, &in_file, &out_file)?,
         Command::Run { in_file } => command::run::run(in_file)?,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ struct Opt {
     command: Command,
 
     /// Target language. Options: c, js, llvm
-    #[structopt(long, short, parse(try_from_str))]
+    #[structopt(long, short, default_value = "js", parse(try_from_str))]
     target: Target,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ extern crate structopt;
 extern crate tempfile;
 
 use std::path::PathBuf;
-use std::str::FromStr;
 use structopt::StructOpt;
+use generator::Target;
 
 mod ast;
 mod builder;
@@ -41,37 +41,6 @@ pub struct Lib;
 #[derive(RustEmbed)]
 #[folder = "builtin/"]
 pub struct Builtins;
-
-#[derive(Debug)]
-enum Target {
-    C,
-    JS,
-    LLVM,
-}
-
-impl FromStr for Target {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.to_lowercase();
-
-        match s.as_str() {
-            #[cfg(feature = "backend_c")]
-            "c" => Ok(Target::C),
-
-            #[cfg(feature = "backend_node")]
-            "js" => Ok(Target::JS),
-
-            #[cfg(feature = "backend_llvm")]
-            "llvm" => Ok(Target::LLVM),
-
-            _ => Err(format!(
-                "no target {T} found, maybe you forgot to enable backend_{T} feature?",
-                T = s
-            )),
-        }
-    }
-}
 
 #[derive(StructOpt, Debug)]
 enum Command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,10 @@ fn main() -> Result<(), String> {
     let opts = Opt::from_args();
 
     match opts.command {
-        Command::Build { in_file, out_file } => command::build::build(opts.target, &in_file, &out_file)?,
-        Command::Run { in_file } => command::run::run(in_file)?,
+        Command::Build { in_file, out_file } => {
+            command::build::build(opts.target, &in_file, &out_file)?
+        }
+        Command::Run { in_file } => command::run::run(opts.target, in_file)?,
     };
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,10 @@ impl FromStr for Target {
             #[cfg(feature = "backend_llvm")]
             "llvm" => Ok(Target::LLVM),
 
-            _ => Err(
-                format!("no target {T} found, maybe you forgot to enable backend_{T} feature?", T = s),
-            ),
+            _ => Err(format!(
+                "no target {T} found, maybe you forgot to enable backend_{T} feature?",
+                T = s
+            )),
         }
     }
 }

--- a/src/tests/test_examples.rs
+++ b/src/tests/test_examples.rs
@@ -25,13 +25,7 @@ fn test_directory(dir_in: &str) -> Result<(), Error> {
 
     let _ = fs::create_dir(&dir_out);
 
-    let out_file_suffix = if cfg!(feature = "backend_node") {
-        ".js"
-    } else if cfg!(feature = "backend_c") {
-        ".c"
-    } else {
-        todo!()
-    };
+    let out_file_suffix = ".js";
 
     for ex in examples {
         let example = ex?;
@@ -59,16 +53,14 @@ fn test_directory(dir_in: &str) -> Result<(), Error> {
             .success();
         assert_eq!(success, true, "{:?}", &in_file);
 
-        if cfg!(feature = "backend_node") {
-            let node_installed = Command::new("node").arg("-v").spawn()?.wait()?.success();
-            if node_installed {
-                let execution = Command::new("node")
-                    .arg(out_file)
-                    .spawn()?
-                    .wait()?
-                    .success();
-                assert_eq!(execution, true, "{:?}", &in_file)
-            }
+        let node_installed = Command::new("node").arg("-v").spawn()?.wait()?.success();
+        if node_installed {
+            let execution = Command::new("node")
+                .arg(out_file)
+                .spawn()?
+                .wait()?
+                .success();
+            assert_eq!(execution, true, "{:?}", &in_file)
         }
     }
     Ok(())

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,7 +15,6 @@
  */
 pub mod string_util;
 
-#[cfg(feature = "backend_c")]
 /// Datatype that holds one of two types
 pub enum Either<L, R> {
     Left(L),


### PR DESCRIPTION
Fixes #20 

### Description

This adds `-t`/`--target` CLI option to select generator backend at runtime instead of recompiling with different options.

### ToDo

- [x] Add option parsing
- [x] Select generator accordingly
- [x] Get rid of `backend_*` options
- [x] Document this
- [x] Add to "Unreleased" section in changelog