### PR TITLE
c: add support for structs

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -126,11 +126,11 @@ impl Builder {
             generator::Target::JS => generator::js::JsGenerator::generate(condensed),
             generator::Target::C => generator::c::CGenerator::generate(condensed),
             generator::Target::LLVM => {
-                #[cfg(feature = "llvm")]
-                return generator::llvm::LLVMGenerator::generate(condensed);
-
                 #[cfg(not(feature = "llvm"))]
                 panic!("'llvm' feature should be enabled to use LLVM target");
+
+                #[cfg(feature = "llvm")]
+                generator::llvm::LLVMGenerator::generate(condensed)
             }
         };
 

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -75,7 +75,7 @@ pub(super) fn generate_type(t: Either<Variable, Option<Type>>) -> String {
             Type::Str => "char *".into(),
             Type::Any => "void *".into(),
             Type::Bool => "bool".into(),
-            Type::Struct(_) => todo!(),
+            Type::Struct(name) => format!("struct {}", name),
             Type::Array(t) => match name {
                 Some(n) => format!(
                     "{T} {N}[]",

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -287,7 +287,7 @@ fn generate_bin_op(left: Expression, op: BinOp, right: Expression) -> String {
 }
 
 fn generate_struct_initialization(fields: HashMap<String, Box<Expression>>) -> String {
-    let mut buf: String = format!("{{");
+    let mut buf: String = String::from("{");
 
     fields.iter().for_each(|(k, v)| {
         buf += &format!(".{} = {},", k, generate_expression(*v.clone()));

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -154,7 +154,7 @@ fn generate_expression(expr: Expression) -> String {
         Expression::ArrayAccess(name, expr) => generate_array_access(name, *expr),
         Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
         Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),
-        Expression::FieldAccess(_, _) => todo!(),
+        Expression::FieldAccess(expr, field) => generate_field_access(*expr, field),
     }
 }
 
@@ -248,7 +248,7 @@ fn generate_function_call(func: String, args: Vec<Expression>) -> String {
             Expression::Array(_) => todo!(),
             Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
             Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),
-            Expression::FieldAccess(_, _) => todo!(),
+            Expression::FieldAccess(expr, field) => generate_field_access(*expr, field)
         })
         .collect::<Vec<String>>()
         .join(",");
@@ -300,6 +300,10 @@ fn generate_struct_initialization(fields: HashMap<String, Box<Expression>>) -> S
     buf += "}";
 
     buf
+}
+
+fn generate_field_access(expr: Expression, field: String) -> String {
+    format!("{}.{}", generate_expression(expr), field)
 }
 
 fn generate_assign(name: Expression, expr: Expression) -> String {

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::ast::types::Type;
 use crate::ast::*;
 /**
@@ -151,7 +153,7 @@ fn generate_expression(expr: Expression) -> String {
         Expression::Array(els) => generate_array(els),
         Expression::ArrayAccess(name, expr) => generate_array_access(name, *expr),
         Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
-        Expression::StructInitialization(_, _) => todo!(),
+        Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),
         Expression::FieldAccess(_, _) => todo!(),
     }
 }
@@ -245,7 +247,7 @@ fn generate_function_call(func: String, args: Vec<Expression>) -> String {
             Expression::Str(s) | Expression::Variable(s) => s,
             Expression::Array(_) => todo!(),
             Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
-            Expression::StructInitialization(_, _) => todo!(),
+            Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),
             Expression::FieldAccess(_, _) => todo!(),
         })
         .collect::<Vec<String>>()
@@ -286,6 +288,18 @@ fn generate_bin_op(left: Expression, op: BinOp, right: Expression) -> String {
         op = op_str,
         r = generate_expression(right)
     )
+}
+
+fn generate_struct_initialization(fields: HashMap<String, Box<Expression>>) -> String {
+    let mut buf: String = format!("{{");
+
+    fields.iter().for_each(|(k, v)| {
+        buf += &format!(".{} = {},", k, generate_expression(*v.clone()));
+    });
+
+    buf += "}";
+
+    buf
 }
 
 fn generate_assign(name: Expression, expr: Expression) -> String {

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -29,6 +29,10 @@ impl Generator for CGenerator {
         code += std::str::from_utf8(raw_builtins.as_ref())
             .expect("Unable to interpret builtin functions");
 
+        let structs: String = prog.structs.into_iter().map(generate_struct).collect();
+
+        code += &structs;
+
         for func in &prog.func {
             code += &format!("{};\n", &generate_function_signature(func.clone()));
         }
@@ -39,6 +43,25 @@ impl Generator for CGenerator {
 
         code
     }
+}
+
+pub fn generate_struct(def: StructDef) -> String {
+    // struct name {
+    let mut buf = format!("struct {} {{\n", def.name);
+
+    def.fields.iter().for_each(|f| {
+        // int counter;
+        buf += &format!(
+            "{} {};\n",
+            generate_type(Either::Left(f.clone())),
+            f.name,
+        );
+    });
+
+    // };
+    buf += "};\n";
+
+    buf
 }
 
 pub(super) fn generate_type(t: Either<Variable, Option<Type>>) -> String {

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -53,11 +53,7 @@ pub fn generate_struct(def: StructDef) -> String {
 
     def.fields.iter().for_each(|f| {
         // int counter;
-        buf += &format!(
-            "{} {};\n",
-            generate_type(Either::Left(f.clone())),
-            f.name,
-        );
+        buf += &format!("{} {};\n", generate_type(Either::Left(f.clone())), f.name,);
     });
 
     // };
@@ -248,7 +244,7 @@ fn generate_function_call(func: String, args: Vec<Expression>) -> String {
             Expression::Array(_) => todo!(),
             Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
             Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),
-            Expression::FieldAccess(expr, field) => generate_field_access(*expr, field)
+            Expression::FieldAccess(expr, field) => generate_field_access(*expr, field),
         })
         .collect::<Vec<String>>()
         .join(",");


### PR DESCRIPTION
### Description

This patch adds support for `struct`s in C generator.

### ToDo

- [x] Generate struct definition
- [x] Generate struct type (type annotations, nested structs)
- [x] Struct creation (`new User { ... }`)
- [x] Field access
