### PR TITLE
feat: allow constructors as function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Allow constructor expressions as function arguments
+
 ## v0.6.0 (2021-02-28)
 
 **Changes**

--- a/src/parser/rules.rs
+++ b/src/parser/rules.rs
@@ -278,7 +278,9 @@ impl Parser {
                 TokenKind::Identifier(_) | TokenKind::Literal(_) => {
                     args.push(self.parse_expression()?)
                 }
-                TokenKind::Keyword(Keyword::Boolean) => args.push(self.parse_expression()?),
+                TokenKind::Keyword(Keyword::Boolean) | TokenKind::Keyword(Keyword::New) => {
+                    args.push(self.parse_expression()?)
+                }
                 TokenKind::SquareBraceOpen => {
                     // TODO: Expression parsing currently uses `next` instead of `peek`.
                     // We have to eat that token here until that is resolved

--- a/tests/structs.sb
+++ b/tests/structs.sb
@@ -75,6 +75,14 @@ fn test_method_call() {
     assert(full_name, "FooBar")
 }
 
+fn assert_bar_y(bar: Bar) {
+    assert(bar.y == "ABC")
+}
+
+fn test_function_call_with_constructor() {
+    assert_bar_y(new Bar { y: "ABC" })
+}
+
 fn main() {
     test_initialization()
     test_simple_field_access()
@@ -82,4 +90,5 @@ fn main() {
     test_field_access_on_function()
     test_nested_structs()
     test_method_call()
+    test_function_call_with_constructor()
 }


### PR DESCRIPTION
Fixes #29

Allow struct constructors as function arguments

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable
