### PR TITLE
#34 self as statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**
 
 - Allow constructor expressions as function arguments
+- Fix `self` keyword inside statement
 
 ## v0.6.0 (2021-02-28)
 

--- a/src/parser/rules.rs
+++ b/src/parser/rules.rs
@@ -201,7 +201,9 @@ impl Parser {
         let token = self.peek()?;
         match &token.kind {
             TokenKind::CurlyBracesOpen => self.parse_block(),
-            TokenKind::BraceOpen => Ok(Statement::Exp(self.parse_expression()?)),
+            TokenKind::BraceOpen | TokenKind::Keyword(Keyword::Selff) => {
+                Ok(Statement::Exp(self.parse_expression()?))
+            }
             TokenKind::Keyword(Keyword::Let) => self.parse_declare(),
             TokenKind::Keyword(Keyword::Return) => self.parse_return(),
             TokenKind::Keyword(Keyword::If) => self.parse_conditional_statement(),

--- a/tests/structs.sb
+++ b/tests/structs.sb
@@ -83,6 +83,20 @@ fn test_function_call_with_constructor() {
     assert_bar_y(new Bar { y: "ABC" })
 }
 
+struct Self_test_struct {
+    a: int
+
+    fn bar() {
+        self.a += 1 // <-- This caused problems (See #34)
+        assert(true)
+    }
+}
+
+fn test_method_with_self_statement() {
+    let foo = new Self_test_struct { a: 5 }
+    foo.bar()
+}
+
 fn main() {
     test_initialization()
     test_simple_field_access()
@@ -91,4 +105,5 @@ fn main() {
     test_nested_structs()
     test_method_call()
     test_function_call_with_constructor()
+    test_method_with_self_statement()
 }


### PR DESCRIPTION
Fixes #34 

Allow `self` keyword as statement

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable
