### PR TITLE
QBE generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Parser errors have been improved in consistency and readability
 - Compile to stdout by using the `-o -` flag
 - Proper support for utf-8
+- Initial support for QBE backend
 
 **Fixes**
 

--- a/docs/developers/backends.md
+++ b/docs/developers/backends.md
@@ -1,6 +1,6 @@
 # Backends
 
-Antimony currently implements a JavaScript backend, but a C backend is in development. WASM, ARM and x86 are planned.
+Antimony currently implements a JavaScript backend, but C and QBE backends are in development. WASM, ARM and x86 are planned.
 
 Backend can be specified when running on building with `--target` (`-t`) option, default is `js`:
 
@@ -13,8 +13,11 @@ sb -t c build in.sb --out-file out
 | Target Language | Identifier     | Stability notice |
 | :-------------- | :------------- | :--------------- |
 | Node.js         | `js`           | mostly stable    |
+| [QBE]           | `qbe`          | work in progess  |
 | LLVM            | `llvm`         | unstable         |
 | C               | `c`            | unstable         |
+
+[QBE]: https://c9x.me/compile
 
 LLVM also requires to enable `llvm` feature when building:
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -45,7 +45,7 @@ impl Builder {
             .to_path_buf())
     }
 
-    pub fn build(&mut self) -> Result<(), String> {
+    pub fn build(&mut self, target: &Target) -> Result<(), String> {
         let in_file = self.in_file.clone();
         // Resolve path deltas between working directory and entrypoint
         let base_directory = self.get_base_path()?;
@@ -61,7 +61,9 @@ impl Builder {
         self.build_module(self.in_file.clone(), &mut Vec::new())?;
 
         // Append standard library
-        self.build_stdlib()?;
+        if matches!(target, Target::JS) {
+            self.build_stdlib()?;
+        }
 
         // Change back to the initial directory
         env::set_current_dir(initial_directory).expect("Could not set current directory");

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -143,6 +143,7 @@ impl Builder {
                 #[cfg(feature = "llvm")]
                 generator::llvm::LLVMGenerator::generate(condensed)
             }
+            Target::Qbe => generator::qbe::QbeGenerator::generate(condensed),
             Target::X86 => generator::x86::X86Generator::generate(condensed),
         };
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -134,17 +134,17 @@ impl Builder {
         }
 
         let output = match target {
-            Target::JS => generator::js::JsGenerator::generate(condensed),
-            Target::C => generator::c::CGenerator::generate(condensed),
+            Target::JS => generator::js::JsGenerator::generate(condensed)?,
+            Target::C => generator::c::CGenerator::generate(condensed)?,
             Target::Llvm => {
                 #[cfg(not(feature = "llvm"))]
                 panic!("'llvm' feature should be enabled to use LLVM target");
 
                 #[cfg(feature = "llvm")]
-                generator::llvm::LLVMGenerator::generate(condensed)
+                generator::llvm::LLVMGenerator::generate(condensed)?
             }
-            Target::Qbe => generator::qbe::QbeGenerator::generate(condensed),
-            Target::X86 => generator::x86::X86Generator::generate(condensed),
+            Target::Qbe => generator::qbe::QbeGenerator::generate(condensed)?,
+            Target::X86 => generator::x86::X86Generator::generate(condensed)?,
         };
 
         buffer.write_all(output.as_bytes()).expect("write failed");

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -42,6 +42,6 @@ pub fn build_to_buffer(
     buf: &mut Box<impl Write>,
 ) -> Result<(), String> {
     let mut b = builder::Builder::new(in_file.to_path_buf());
-    b.build()?;
+    b.build(target)?;
     b.generate(target, buf)
 }

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
-
 use crate::ast::types::Type;
 use crate::ast::*;
-use crate::generator::Generator;
+use crate::generator::{Generator, GeneratorResult};
 use crate::util::Either;
+use std::collections::HashMap;
 
 pub struct CGenerator;
 
 impl Generator for CGenerator {
-    fn generate(prog: Module) -> String {
+    fn generate(prog: Module) -> GeneratorResult<String> {
         let mut code = String::new();
 
         let raw_builtins =
@@ -43,7 +42,7 @@ impl Generator for CGenerator {
 
         code += &funcs;
 
-        code
+        Ok(code)
     }
 }
 

--- a/src/generator/js.rs
+++ b/src/generator/js.rs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 use crate::ast::*;
-use crate::generator::Generator;
+use crate::generator::{Generator, GeneratorResult};
 use std::collections::HashMap;
 use types::Type;
 
 pub struct JsGenerator;
 
 impl Generator for JsGenerator {
-    fn generate(prog: Module) -> String {
+    fn generate(prog: Module) -> GeneratorResult<String> {
         let mut code = String::new();
 
         let raw_builtins =
@@ -44,7 +44,7 @@ impl Generator for JsGenerator {
 
         code += "main();";
 
-        code
+        Ok(code)
     }
 }
 

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -21,6 +21,7 @@ pub mod c;
 pub mod js;
 #[cfg(feature = "llvm")]
 pub mod llvm;
+pub mod qbe;
 #[cfg(test)]
 mod tests;
 pub mod x86;
@@ -30,6 +31,7 @@ pub enum Target {
     C,
     JS,
     Llvm,
+    Qbe,
     X86,
 }
 
@@ -42,6 +44,7 @@ impl Target {
         match &*ext.to_string_lossy() {
             "c" => Some(Self::C),
             "js" => Some(Self::JS),
+            "ssa" => Some(Self::Qbe),
             "s" => Some(Self::X86),
             _ => None,
         }
@@ -58,6 +61,7 @@ impl FromStr for Target {
             "c" => Ok(Target::C),
             "js" => Ok(Target::JS),
             "llvm" => Ok(Target::Llvm),
+            "qbe" => Ok(Target::Qbe),
             "x86" => Ok(Target::X86),
             _ => Err(format!("no target {} found", s)),
         }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -68,8 +68,10 @@ impl FromStr for Target {
     }
 }
 
+pub type GeneratorResult<T> = Result<T, String>;
+
 pub trait Generator {
-    fn generate(prog: Module) -> String;
+    fn generate(prog: Module) -> GeneratorResult<String>;
 }
 
 /// Returns C syntax representation of a raw string

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -107,7 +107,11 @@ impl QbeGenerator {
                 self.scopes.pop();
             }
             Statement::Return(val) => match val {
-                Some(_) => todo!("expressions"),
+                Some(expr) => {
+                    let (_, result) = self.generate_expression(func, expr)?;
+                    // TODO: Cast to function return type
+                    func.add_instr(QbeInstr::Ret(Some(result)));
+                }
                 None => func.add_instr(QbeInstr::Ret(None)),
             },
             _ => todo!("statement: {:?}", stmt),

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -146,6 +146,7 @@ impl QbeGenerator {
 
                 Ok((QbeType::Word, tmp))
             }
+            Expression::Variable(name) => self.get_var(name).map(|v| v.to_owned()),
             Expression::BinOp(lhs, op, rhs) => {
                 let (_, lhs) = self.generate_expression(func, &lhs)?;
                 let (_, rhs) = self.generate_expression(func, &rhs)?;

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -544,7 +544,15 @@ impl QbeGenerator {
             Type::Int => Ok(QbeType::Word),
             Type::Bool => Ok(QbeType::Byte),
             Type::Str => Ok(QbeType::Long),
-            Type::Array(..) | Type::Struct(_) => todo!("aggregate types"),
+            Type::Struct(name) => {
+                let (ty, ..) = self
+                    .struct_map
+                    .get(&name)
+                    .ok_or_else(|| format!("Use of undeclared struct '{}'", name))?
+                    .to_owned();
+                Ok(ty)
+            }
+            Type::Array(..) => todo!("array types"),
         }
     }
 }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -136,6 +136,16 @@ impl QbeGenerator {
 
                 Ok((QbeType::Word, tmp))
             }
+            Expression::Bool(literal) => {
+                let tmp = self.new_temporary();
+                func.assign_instr(
+                    tmp.clone(),
+                    QbeType::Word,
+                    QbeInstr::Copy(Either::Right(if *literal { 1 } else { 0 })),
+                );
+
+                Ok((QbeType::Word, tmp))
+            }
             _ => todo!("expression: {:?}", expr),
         }
     }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use super::Generator;
+use super::{Generator, GeneratorResult};
 use crate::ast::*;
 
 pub struct QbeGenerator;
 
 impl Generator for QbeGenerator {
-    fn generate(_prog: Module) -> String {
+    fn generate(_prog: Module) -> GeneratorResult<String> {
         todo!();
     }
 }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -655,7 +655,7 @@ impl QbeGenerator {
                     .to_owned();
                 Ok(ty)
             }
-            Type::Array(..) => todo!("array types"),
+            Type::Array(..) => Ok(QbeType::Long),
         }
     }
 }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -151,6 +151,9 @@ impl QbeGenerator {
                     return Err("continue used outside of a loop".to_owned());
                 }
             }
+            Statement::Exp(expr) => {
+                self.generate_expression(func, expr)?;
+            }
             _ => todo!("statement: {:?}", stmt),
         }
         Ok(())

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -93,7 +93,7 @@ impl QbeGenerator {
             )?;
 
             meta.insert(field.name.clone(), (ty.clone(), offset));
-            typedef.items.push(ty.clone());
+            typedef.items.push((ty.clone(), 1));
 
             offset += ty.size();
         }
@@ -1016,8 +1016,7 @@ struct QbeTypeDef {
     name: String,
     align: Option<u64>,
     // TODO: Opaque types?
-    // TODO: Fills (e.g. { w 100 })
-    items: Vec<QbeType>,
+    items: Vec<(QbeType, usize)>,
 }
 
 impl fmt::Display for QbeTypeDef {
@@ -1032,7 +1031,11 @@ impl fmt::Display for QbeTypeDef {
             "{{ {} }}",
             self.items
                 .iter()
-                .map(|i| format!("{}", i))
+                .map(|(ty, count)| if *count > 1 {
+                    format!("{} {}", ty, count)
+                } else {
+                    format!("{}", ty)
+                })
                 .collect::<Vec<String>>()
                 .join(", "),
         )
@@ -1274,11 +1277,11 @@ mod tests {
         let typedef = QbeTypeDef {
             name: "person".into(),
             align: None,
-            items: vec![QbeType::Long, QbeType::Word, QbeType::Byte],
+            items: vec![(QbeType::Long, 1), (QbeType::Word, 2), (QbeType::Byte, 1)],
         };
 
         let formatted = format!("{}", typedef);
-        assert_eq!(formatted, "type :person = { l, w, b }");
+        assert_eq!(formatted, "type :person = { l, w 2, b }");
     }
 
     #[test]

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -144,6 +144,13 @@ impl QbeGenerator {
                     return Err("break used outside of a loop".to_owned());
                 }
             }
+            Statement::Continue => {
+                if let Some(label) = &self.loop_label {
+                    func.add_instr(QbeInstr::Jmp(format!("{}.cond", label)));
+                } else {
+                    return Err("continue used outside of a loop".to_owned());
+                }
+            }
             _ => todo!("statement: {:?}", stmt),
         }
         Ok(())

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -111,17 +111,15 @@ impl QbeGenerator {
 
         let mut arguments: Vec<(QbeType, QbeValue)> = Vec::new();
         for arg in &func.arguments {
-            let ty = self
-                .get_type(
-                    arg.ty
-                        .as_ref()
-                        .ok_or("Function arguments must have a type")?
-                        .to_owned(),
-                )?
-                .into_abi();
+            let ty = self.get_type(
+                arg.ty
+                    .as_ref()
+                    .ok_or("Function arguments must have a type")?
+                    .to_owned(),
+            )?;
             let tmp = self.new_var(&ty, &arg.name)?;
 
-            arguments.push((ty, tmp));
+            arguments.push((ty.into_abi(), tmp));
         }
 
         let return_ty = if let Some(ty) = &func.ret_type {

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2021 Alexey Yerin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use super::Generator;
+use crate::ast::*;
+
+pub struct QbeGenerator;
+
+impl Generator for QbeGenerator {
+    fn generate(_prog: Module) -> String {
+        todo!();
+    }
+}
+
+use std::fmt;
+
+/// QBE instruction
+#[derive(Debug)]
+enum QbeInstr {
+    /// Return from a function, optionally with a value
+    Ret(Option<QbeTemporary>),
+}
+
+impl fmt::Display for QbeInstr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ret(val) => match val {
+                Some(val) => write!(f, "ret {}", val),
+                None => write!(f, "ret"),
+            },
+        }
+    }
+}
+
+/// QBE type
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[allow(dead_code)]
+enum QbeType {
+    // Base types
+    Word,
+    Long,
+    Single,
+    Double,
+
+    // Extended types
+    Byte,
+    Halfword,
+
+    /// Aggregate type with a specified name
+    Aggregate(String),
+}
+
+impl QbeType {
+    /// Returns a C ABI type. Extended types are converted to closest base
+    /// types
+    fn into_abi(self) -> Self {
+        match self {
+            Self::Byte | Self::Halfword => Self::Word,
+            other => other,
+        }
+    }
+}
+
+impl fmt::Display for QbeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Word => write!(f, "w"),
+            Self::Long => write!(f, "l"),
+            Self::Single => write!(f, "s"),
+            Self::Double => write!(f, "d"),
+
+            Self::Byte => write!(f, "b"),
+            Self::Halfword => write!(f, "h"),
+
+            Self::Aggregate(name) => write!(f, ":{}", name),
+        }
+    }
+}
+
+/// QBE temporary
+#[derive(Debug, Clone)]
+struct QbeTemporary {
+    name: String,
+}
+
+impl QbeTemporary {
+    /// Returns a new temporary
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl fmt::Display for QbeTemporary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "%{}", self.name)
+    }
+}
+
+/// An IR statement
+#[derive(Debug)]
+enum QbeStatement {
+    Assign(QbeTemporary, QbeType, QbeInstr),
+    Volatile(QbeInstr),
+}
+
+impl fmt::Display for QbeStatement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Assign(temp, ty, instr) => {
+                write!(f, "{} ={} {}", temp, ty, instr)
+            }
+            Self::Volatile(instr) => write!(f, "{}", instr),
+        }
+    }
+}
+
+/// Function block with a label
+#[derive(Debug)]
+struct QbeBlock {
+    /// Label before the block
+    label: String,
+
+    /// A list of instructions in the block
+    instructions: Vec<QbeStatement>,
+}
+
+impl QbeBlock {
+    /// Adds a new instruction to the block
+    fn add_instr(&mut self, instr: QbeInstr) {
+        self.instructions.push(QbeStatement::Volatile(instr));
+    }
+
+    /// Adds a new instruction assigned to a temporary
+    fn assign_instr(&mut self, temp: QbeTemporary, ty: QbeType, instr: QbeInstr) {
+        self.instructions.push(QbeStatement::Assign(temp, ty, instr));
+    }
+}
+
+impl fmt::Display for QbeBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "@{}", self.label)?;
+
+        write!(
+            f,
+            "{}",
+            self.instructions
+                .iter()
+                .map(|instr| format!("\t{}", instr))
+                .collect::<Vec<String>>()
+                .join("\n")
+        )
+    }
+}
+
+/// QBE function
+#[derive(Debug)]
+struct QbeFunction {
+    /// Should the function be available to outside users
+    exported: bool,
+
+    /// Function name
+    name: String,
+
+    /// Function arguments
+    arguments: Vec<(QbeType, QbeTemporary)>,
+
+    /// Return type
+    return_ty: Option<QbeType>,
+
+    /// Labelled blocks
+    blocks: Vec<QbeBlock>,
+}
+
+impl QbeFunction {
+    /// Adds a new empty block with a specified label
+    fn add_block(&mut self, label: String) {
+        self.blocks.push(QbeBlock {
+            label,
+            instructions: Vec::new(),
+        });
+    }
+
+    /// Adds a new instruction to the last block
+    fn add_instr(&mut self, instr: QbeInstr) {
+        self.blocks
+            .last_mut()
+            .expect("Last block must be present")
+            .add_instr(instr);
+    }
+
+    /// Adds a new instruction assigned to a temporary
+    fn assign_instr(&mut self, temp: QbeTemporary, ty: QbeType, instr: QbeInstr) {
+        self.blocks
+            .last_mut()
+            .expect("Last block must be present")
+            .assign_instr(temp, ty, instr);
+    }
+}
+
+impl fmt::Display for QbeFunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.exported {
+            write!(f, "export ")?;
+        }
+        write!(f, "function")?;
+        if let Some(ty) = &self.return_ty {
+            write!(f, " {}", ty)?;
+        }
+
+        writeln!(
+            f,
+            " ${name}({args}) {{",
+            name = self.name,
+            args = self
+                .arguments
+                .iter()
+                .map(|(ty, temp)| format!("{} {}", ty, temp))
+                .collect::<Vec<String>>()
+                .join(", "),
+        )?;
+
+        for blk in self.blocks.iter() {
+            writeln!(f, "{}", blk)?;
+        }
+
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temporary() {
+        let tmp = QbeTemporary::new("temp42".into());
+        assert_eq!(format!("{}", tmp), "%temp42");
+    }
+
+    #[test]
+    fn block() {
+        let blk = QbeBlock {
+            label: "start".into(),
+            instructions: vec![QbeStatement::Volatile(QbeInstr::Ret(None))],
+        };
+
+        let formatted = format!("{}", blk);
+        let mut lines = formatted.lines();
+        assert_eq!(lines.next().unwrap(), "@start");
+        assert_eq!(lines.next().unwrap(), "\tret");
+
+        let blk = QbeBlock {
+            label: "start".into(),
+            instructions: vec![
+                QbeStatement::Volatile(QbeInstr::Ret(None)),
+                QbeStatement::Volatile(QbeInstr::Ret(None)),
+            ],
+        };
+
+        let formatted = format!("{}", blk);
+        let mut lines = formatted.lines();
+        assert_eq!(lines.next().unwrap(), "@start");
+        assert_eq!(lines.next().unwrap(), "\tret");
+        assert_eq!(lines.next().unwrap(), "\tret");
+    }
+
+    #[test]
+    fn function() {
+        let func = QbeFunction {
+            exported: true,
+            return_ty: None,
+            name: "main".into(),
+            arguments: Vec::new(),
+            blocks: vec![QbeBlock {
+                label: "start".into(),
+                instructions: vec![QbeStatement::Volatile(QbeInstr::Ret(None))],
+            }],
+        };
+
+        let formatted = format!("{}", func);
+        let mut lines = formatted.lines();
+        assert_eq!(lines.next().unwrap(), "export function $main() {");
+        assert_eq!(lines.next().unwrap(), "@start");
+        assert_eq!(lines.next().unwrap(), "\tret");
+        assert_eq!(lines.next().unwrap(), "}");
+    }
+
+    #[test]
+    fn type_into_abi() {
+        // Base types and aggregates should stay unchanged
+        let unchanged = |ty: QbeType| assert_eq!(ty.clone().into_abi(), ty);
+        unchanged(QbeType::Word);
+        unchanged(QbeType::Long);
+        unchanged(QbeType::Single);
+        unchanged(QbeType::Double);
+        unchanged(QbeType::Aggregate("foo".into()));
+
+        // Extended types are transformed into closest base types
+        assert_eq!(QbeType::Byte.into_abi(), QbeType::Word);
+        assert_eq!(QbeType::Halfword.into_abi(), QbeType::Word);
+    }
+}

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -684,6 +684,35 @@ impl fmt::Display for QbeDataItem {
     }
 }
 
+/// QBE aggregate type definition
+#[derive(Debug)]
+struct QbeTypeDef {
+    name: String,
+    align: Option<u64>,
+    // TODO: Opaque types?
+    // TODO: Fills (e.g. { w 100 })
+    items: Vec<QbeType>,
+}
+
+impl fmt::Display for QbeTypeDef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "type :{} = ", self.name)?;
+        if let Some(align) = self.align {
+            write!(f, "align {} ", align)?;
+        }
+
+        write!(
+            f,
+            "{{ {} }}",
+            self.items
+                .iter()
+                .map(|i| format!("{}", i))
+                .collect::<Vec<String>>()
+                .join(", "),
+        )
+    }
+}
+
 /// An IR statement
 #[derive(Debug)]
 enum QbeStatement {
@@ -911,6 +940,18 @@ mod tests {
             formatted,
             "export data $hello = { b \"Hello, World!\", b 0 }"
         );
+    }
+
+    #[test]
+    fn typedef() {
+        let typedef = QbeTypeDef {
+            name: "person".into(),
+            align: None,
+            items: vec![QbeType::Long, QbeType::Word, QbeType::Byte],
+        };
+
+        let formatted = format!("{}", typedef);
+        assert_eq!(formatted, "type :person = { l, w, b }");
     }
 
     #[test]

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -106,6 +106,20 @@ impl QbeGenerator {
                 }
                 self.scopes.pop();
             }
+            Statement::Declare(var, expr) => {
+                let ty = self.get_type(
+                    var.ty
+                        .as_ref()
+                        .ok_or_else(|| format!("Missing type for variable '{}'", &var.name))?
+                        .to_owned(),
+                )?;
+                let tmp = self.new_var(&ty, &var.name)?;
+
+                if let Some(expr) = expr {
+                    let (ty, result) = self.generate_expression(func, expr)?;
+                    func.assign_instr(tmp, ty, QbeInstr::Copy(Either::Left(result)));
+                }
+            }
             Statement::Return(val) => match val {
                 Some(expr) => {
                     let (_, result) = self.generate_expression(func, expr)?;

--- a/src/generator/x86.rs
+++ b/src/generator/x86.rs
@@ -1,4 +1,3 @@
-use crate::ast::{Function, Module, Statement};
 /**
  * Copyright 2020 Garrit Franke
  *
@@ -14,7 +13,8 @@ use crate::ast::{Function, Module, Statement};
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::generator::Generator;
+use crate::ast::{Function, Module, Statement};
+use crate::generator::{Generator, GeneratorResult};
 
 struct Assembly {
     asm: Vec<String>,
@@ -43,8 +43,8 @@ impl Assembly {
 pub struct X86Generator;
 
 impl Generator for X86Generator {
-    fn generate(prog: Module) -> String {
-        Self::new().gen_program(prog).build()
+    fn generate(prog: Module) -> GeneratorResult<String> {
+        Ok(Self::new().gen_program(prog).build())
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,7 @@
 pub mod string_util;
 
 /// Datatype that holds one of two types
+#[derive(Debug)]
 pub enum Either<L, R> {
     Left(L),
     Right(R),


### PR DESCRIPTION
### Description

This adds a generator for [QBE]. This time it should go a bit better.

[QBE]: https://c9x.me/compile

### Notes

* Extended types are *only* allowed in data definitions (aka aggregate types)
* Casting to a larger type doesn't work, needs to be explicitly extended with `ext*` instructions

### Demo time

```rust
struct Person {
    beans: int
}

fn main() {
    let me = new Person {
        beans: 0
    }

    printf("before: %d beans\n", me.beans)

    me.beans += 100

    printf("after: %d beans\n", me.beans)
}
```

Produces:

```
$ ./target/debug/sb -t qbe build -o - test.sb | qbe | cc -x assembler -o test -
$ ./test
before: 0 beans
after: 100 beans
```

### Known issues

* Function calls don't have correct return types. If you call a C function that returns a `long` and pass it into something else, it will break. Blocked on better types and function prototype syntax.

### ToDo

- [x] Functions
- Control structures
  - [x] Return
  - [x] If statement
  - [ ] For loop (requires arrays)
  - [x] While loop
  - [x] Break/continue from loops
  - [ ] Match
- Expressions
  - [x] Integer literals
  - [x] Boolean literals
  - [x] String literals (requires string aggregate type)
  - [x] Function calls (a bit fragile right now)
  - [x] Variable access
  - [x] Binary operations (`+`, `-` and friends)
  - [x] Assignment operations (`+=`, `*=` etc)
  - [ ] Self in methods (if methods will live to this point)
- Aggregate types
  - Arrays
    - [x] `[..., ....]` initialization syntax
    - [ ] Array access
    - [ ] Assignment to array
    - [ ] Nested arrays?
  - Structs
    - [x] Struct initialization (`new Database { ... }`)
    - [x] Resolve structs in variable types
    - [x] Field access
    - [x] Assignment to fields
    - [ ] Nested structs
  - [x] Strings. Like C, with NUL terminator
- [ ] Make `sb build` assemble and link the binary
- [ ] Add tests
- [x] Document the new backend
- [x] Add to "Unreleased" section in the changelog