### PR TITLE
Improve parser errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Instead of a temporary directory, heap memory is used for compilation
 - Support for binary, hexadecimal and octal number notations
 - Support for `_` character in integers (E.g. `1_000_000`)
+- Parser errors have been improved in consistency and readability
 
 **Fixes**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate structopt;
 
 use generator::Target;
 use std::path::PathBuf;
+use std::process;
 use structopt::StructOpt;
 
 mod ast;
@@ -61,7 +62,14 @@ struct Opt {
     target: Option<Target>,
 }
 
-fn main() -> Result<(), String> {
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("Error: {}", err);
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
     let opts = Opt::from_args();
 
     match opts.command {

--- a/src/util/string_util.rs
+++ b/src/util/string_util.rs
@@ -16,17 +16,21 @@
 use crate::lexer::Position;
 
 pub fn highlight_position_in_file(input: String, position: Position) -> String {
-    // TODO: Chain without collecting in between
-    input
-        .chars()
-        .skip(position.raw)
-        .take_while(|c| c != &'\n')
-        .collect::<String>()
-        .chars()
-        .rev()
-        .take_while(|c| c != &'\n')
-        .collect::<String>()
-        .chars()
-        .rev()
-        .collect::<String>()
+    let mut buf = String::new();
+
+    let line = input.lines().nth(position.line - 1).unwrap();
+    // TODO: do something better, code can be more than 9999 lines
+    buf.push_str(&format!("{:>4} | {}\n", position.line, line));
+    buf.push_str("     | ");
+
+    buf.push_str(
+        &line
+            .chars()
+            .take(position.offset - 1)
+            .map(|c| if c == '\t' { '\t' } else { ' ' })
+            .collect::<String>(),
+    );
+    buf.push('^');
+
+    buf
 }


### PR DESCRIPTION
### Description

This PR improves a little bit on parser errors, they are now consistent and easier to read:

```
Error: 2:6: Expected Identifier, found Assign
   2 |  let =
     |      ^
```

It shows the exact position, as well as pointing out where the error is in the source file. Inspired a lot by Rust and Zig :D

### ToDo

- [ ] ~~Proposed feature/fix is sufficiently tested~~
- [ ] ~~Proposed feature/fix is sufficiently documented~~
- [x] The "Unreleased" section in the changelog has been updated, if applicable
