### PR TITLE
Qbe vendor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/qbe"]
+	path = vendor/qbe
+	url = https://git.sr.ht/~sircmpwn/qbe

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+// Example custom build script.
+fn main() -> std::io::Result<()> {
+    
+    println!("cargo:warning=QBE source has changed. Recompiling...");
+
+    let success = Command::new("make")
+        .arg("-C")
+        .arg("vendor/qbe")
+        .spawn()?
+        .wait()?
+        .success();
+
+    match success {
+        true => println!("cargo:warning=Successfully compiled QBE"),
+        false => panic!("cargo:warning=QBE compilation failed"),
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes NULL

### Description

Compiles QBE during Antimony build process and embeds it into the binary

### Changes proposed in this pull request

- QBE source is vendored in `vendor/`
- Introduce cargo build script

### ToDo

- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable
