### PR TITLE
Strings rework

### DIFF
--- a/docs/developers/specification.md
+++ b/docs/developers/specification.md
@@ -137,7 +137,7 @@ return
 self
 struct
 true
-while 
+while
 ```
 
 ### Operators and Punctuation
@@ -234,16 +234,36 @@ sequence of characters. String literals are character sequences between double
 quotes, as in "bar". Within the quotes, any character may appear except newline
 and unescaped double quote.
 
-TODO: escapes
+If `\` character appears in the string, the character(s) following it *must* be
+interpreted specially:
+
+1. `\` and `"` are included unchanged (e.g. `"C:\\Users"` -> `C:\Users`)
+2. `n` emits the newline control chracter (U+000A)
+3. `r` emits the carriage return control chracter (U+000D)
+4. `b` emits the backspace control character (U+000C)
+5. `t` emits a horizontal tab (U+0009)
+6. `f` emits a form feed (U+000C)
+7. Unknown escape sequences *must* raise a compile error
+
 TODO: byte values
 
 TODO: Currently, `"` and `'` are valid string characters. Remove `'` and only
 use them for runes.
 
 ```
-string_lit = `"` unicode_value `"` .
+string_escape =
+    "\n" | # Newline (U+000A)
+    "\r" | # Carriage return (U+000D)
+    "\t" | # Horizontal tab (U+0009)
+    "\f" | # Form feed (U+000C)
+    "\b" | # Backspace (U+0008)
+    `\"` | "\\"
+any = /* Any Unicode code point except newline (U+000A) and double quote (U+0022) */ .
+string_lit = `"` { any | string_escape } `"` .
 
 "abc"
 "Hello, world!"
+"Hello\nworld"
+"C:\\Users" # Should emit C:\Users
 "日本語"
 ```

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -129,7 +129,7 @@ impl TryFrom<Token> for Expression {
                 "false" => Ok(Expression::Bool(false)),
                 _ => Err("Boolean value could not be parsed".into()),
             },
-            TokenKind::Literal(Value::Str) => Ok(Expression::Str(token.raw)),
+            TokenKind::Literal(Value::Str(string)) => Ok(Expression::Str(string)),
             _ => Err("Value could not be parsed".into()),
         }
     }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -61,7 +61,7 @@ impl Builder {
         self.build_module(self.in_file.clone(), &mut Vec::new())?;
 
         // Append standard library
-        self.build_stdlib();
+        self.build_stdlib()?;
 
         // Change back to the initial directory
         env::set_current_dir(initial_directory).expect("Could not set current directory");
@@ -87,7 +87,7 @@ impl Builder {
 
         file.read_to_string(&mut contents)
             .expect("Could not read file");
-        let tokens = lexer::tokenize(&contents);
+        let tokens = lexer::tokenize(&contents)?;
         let module = parser::parse(
             tokens,
             Some(contents),
@@ -148,7 +148,7 @@ impl Builder {
         buffer.flush().map_err(|_| "Could not flush file".into())
     }
 
-    fn build_stdlib(&mut self) {
+    fn build_stdlib(&mut self) -> Result<(), String> {
         let assets = Lib::iter();
 
         for file in assets {
@@ -156,10 +156,12 @@ impl Builder {
                 Lib::get(&file).expect("Standard library not found. This should not occur.");
             let stblib_str =
                 std::str::from_utf8(&stdlib_raw).expect("Could not interpret standard library.");
-            let stdlib_tokens = lexer::tokenize(&stblib_str);
+            let stdlib_tokens = lexer::tokenize(&stblib_str)?;
             let module = parser::parse(stdlib_tokens, Some(stblib_str.into()), file.to_string())
                 .expect("Could not parse stdlib");
             self.modules.push(module);
         }
+
+        Ok(())
     }
 }

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-
-use crate::ast::types::Type;
-use crate::ast::*;
 /**
  * Copyright 2020 Garrit Franke
  *
@@ -17,6 +13,10 @@ use crate::ast::*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
+
+use crate::ast::types::Type;
+use crate::ast::*;
 use crate::generator::Generator;
 use crate::util::Either;
 
@@ -146,7 +146,8 @@ fn generate_statement(statement: Statement) -> String {
 fn generate_expression(expr: Expression) -> String {
     match expr {
         Expression::Int(val) => val.to_string(),
-        Expression::Variable(val) | Expression::Str(val) => val,
+        Expression::Variable(val) => val,
+        Expression::Str(val) => super::string_syntax(val),
         Expression::Bool(b) => b.to_string(),
         Expression::FunctionCall(name, e) => generate_function_call(name, e),
         Expression::Array(size, els) => generate_array(size, els),
@@ -176,8 +177,8 @@ fn generate_array(_size: usize, elements: Vec<Expression>) -> String {
     out_str += &elements
         .iter()
         .map(|el| match el {
-            Expression::Int(x) => x.to_string(),
-            Expression::Str(x) => x.to_string(),
+            Expression::Int(i) => i.to_string(),
+            Expression::Str(s) => super::string_syntax(s.to_owned()),
             _ => todo!("Not yet implemented"),
         })
         .collect::<Vec<String>>()
@@ -244,7 +245,8 @@ fn generate_function_call(func: String, args: Vec<Expression>) -> String {
             Expression::Bool(v) => v.to_string(),
             Expression::ArrayAccess(name, expr) => generate_array_access(name, *expr),
             Expression::FunctionCall(n, a) => generate_function_call(n, a),
-            Expression::Str(s) | Expression::Variable(s) => s,
+            Expression::Str(s) => super::string_syntax(s),
+            Expression::Variable(s) => s,
             Expression::Array(_, _) => todo!(),
             Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
             Expression::StructInitialization(_, fields) => generate_struct_initialization(fields),

--- a/src/generator/js.rs
+++ b/src/generator/js.rs
@@ -1,4 +1,3 @@
-use crate::ast::*;
 /**
  * Copyright 2020 Garrit Franke
  *
@@ -14,6 +13,7 @@ use crate::ast::*;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use crate::ast::*;
 use crate::generator::Generator;
 use std::collections::HashMap;
 use types::Type;
@@ -148,7 +148,8 @@ fn generate_expression(expr: Expression) -> String {
     match expr {
         Expression::Int(val) => val.to_string(),
         Expression::Selff => "this".to_string(),
-        Expression::Variable(val) | Expression::Str(val) => val,
+        Expression::Str(val) => super::string_syntax(val),
+        Expression::Variable(val) => val,
         Expression::Bool(b) => b.to_string(),
         Expression::FunctionCall(name, e) => generate_function_call(name, e),
         Expression::Array(_, els) => generate_array(els),
@@ -301,7 +302,8 @@ fn generate_function_call(func: String, args: Vec<Expression>) -> String {
             Expression::Selff => "this".to_string(),
             Expression::ArrayAccess(name, expr) => generate_array_access(name, *expr),
             Expression::FunctionCall(n, a) => generate_function_call(n, a),
-            Expression::Str(s) | Expression::Variable(s) => s,
+            Expression::Str(s) => super::string_syntax(s),
+            Expression::Variable(s) => s,
             Expression::Array(_, elements) => generate_array(elements),
             Expression::BinOp(left, op, right) => generate_bin_op(*left, op, *right),
             Expression::StructInitialization(name, fields) => {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -67,3 +67,22 @@ impl FromStr for Target {
 pub trait Generator {
     fn generate(prog: Module) -> String;
 }
+
+/// Returns C syntax representation of a raw string
+pub fn string_syntax(raw: String) -> String {
+    format!(
+        "\"{}\"",
+        raw.chars()
+            .map(|c| match c {
+                '\n' => "\\n".to_string(),
+                '\r' => "\\r".to_string(),
+                '\t' => "\\t".to_string(),
+                '\u{000C}' => "\\f".to_string(),
+                '\u{0008}' => "\\b".to_string(),
+                '\\' => "\\\\".to_string(),
+                '"' => "\"".to_string(),
+                other => other.to_string(),
+            })
+            .collect::<String>(),
+    )
+}

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -146,7 +146,7 @@ fn test_string() {
         tokens.next().unwrap(),
         Token {
             len: 5,
-            kind: TokenKind::Literal(Value::Str),
+            kind: TokenKind::Literal(Value::Str("aaa".into())),
             raw: "'aaa'".to_owned(),
             pos: Position {
                 raw: 4,
@@ -160,7 +160,7 @@ fn test_string() {
         tokens.nth(1).unwrap(),
         Token {
             len: 5,
-            kind: TokenKind::Literal(Value::Str),
+            kind: TokenKind::Literal(Value::Str("bbb".into())),
             raw: "\"bbb\"".to_owned(),
             pos: Position {
                 raw: 10,
@@ -179,7 +179,7 @@ fn test_string_markers_within_string() {
         tokens.next().unwrap(),
         Token {
             len: 6,
-            kind: TokenKind::Literal(Value::Str),
+            kind: TokenKind::Literal(Value::Str("\"aaa".into())),
             raw: "'\"aaa'".to_owned(),
             pos: Position {
                 raw: 5,
@@ -193,7 +193,7 @@ fn test_string_markers_within_string() {
         tokens.nth(1).unwrap(),
         Token {
             len: 6,
-            kind: TokenKind::Literal(Value::Str),
+            kind: TokenKind::Literal(Value::Str("'bbb".into())),
             raw: "\"'bbb\"".to_owned(),
             pos: Position {
                 raw: 12,

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -17,7 +17,7 @@ use crate::lexer::*;
 
 #[test]
 fn test_basic_tokenizing() {
-    let raw = tokenize("1 = 2");
+    let raw = tokenize("1 = 2").unwrap();
     let mut tokens = raw.into_iter();
 
     assert_eq!(
@@ -93,7 +93,7 @@ fn test_basic_tokenizing() {
 
 #[test]
 fn test_tokenizing_without_whitespace() {
-    let mut tokens = tokenize("1=2").into_iter();
+    let mut tokens = tokenize("1=2").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -140,7 +140,7 @@ fn test_tokenizing_without_whitespace() {
 
 #[test]
 fn test_string() {
-    let mut tokens = tokenize("'aaa' \"bbb\"").into_iter();
+    let mut tokens = tokenize("'aaa' \"bbb\"").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -173,7 +173,7 @@ fn test_string() {
 
 #[test]
 fn test_string_markers_within_string() {
-    let mut tokens = tokenize("'\"aaa' \"'bbb\"").into_iter();
+    let mut tokens = tokenize("'\"aaa' \"'bbb\"").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -206,7 +206,7 @@ fn test_string_markers_within_string() {
 
 #[test]
 fn test_numbers() {
-    let mut tokens = tokenize("42").into_iter();
+    let mut tokens = tokenize("42").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -225,7 +225,7 @@ fn test_numbers() {
 
 #[test]
 fn test_binary_numbers() {
-    let mut tokens = tokenize("0b101010").into_iter();
+    let mut tokens = tokenize("0b101010").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -244,7 +244,7 @@ fn test_binary_numbers() {
 
 #[test]
 fn test_octal_numbers() {
-    let mut tokens = tokenize("0o52").into_iter();
+    let mut tokens = tokenize("0o52").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -263,7 +263,7 @@ fn test_octal_numbers() {
 
 #[test]
 fn test_hex_numbers() {
-    let mut tokens = tokenize("0x2A").into_iter();
+    let mut tokens = tokenize("0x2A").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -282,7 +282,7 @@ fn test_hex_numbers() {
 
 #[test]
 fn test_functions() {
-    let mut tokens = tokenize("fn fib() {}").into_iter();
+    let mut tokens = tokenize("fn fib() {}").unwrap().into_iter();
 
     assert_eq!(
         tokens.next().unwrap(),
@@ -306,6 +306,7 @@ fn test_comments() {
 fn fib() {}
         ",
     )
+    .unwrap()
     .into_iter()
     .filter(|t| {
         t.kind != TokenKind::Whitespace

--- a/src/parser/rules.rs
+++ b/src/parser/rules.rs
@@ -171,14 +171,17 @@ impl Parser {
 
     fn parse_import(&mut self) -> Result<String, String> {
         self.match_keyword(Keyword::Import)?;
-        let import_path_token = self.match_token(TokenKind::Literal(Value::Str))?;
+        let token = self.next()?;
+        let path = match token.kind {
+            TokenKind::Literal(Value::Str(path)) => path,
+            other => {
+                return Err(
+                    self.make_error_msg(token.pos, format!("Expected string, got {:?}", other))
+                )
+            }
+        };
 
-        // Remove leading and trailing string tokens
-        let mut chars = import_path_token.raw.chars();
-        chars.next();
-        chars.next_back();
-
-        Ok(chars.collect())
+        Ok(path)
     }
 
     fn parse_type(&mut self) -> Result<Type, String> {
@@ -355,7 +358,7 @@ impl Parser {
                 Expression::Int(val)
             }
             // "A string"
-            TokenKind::Literal(Value::Str) => Expression::Str(token.raw),
+            TokenKind::Literal(Value::Str(string)) => Expression::Str(string),
             // self
             TokenKind::Keyword(Keyword::Selff) => Expression::Selff,
             TokenKind::Identifier(val) => {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -20,7 +20,7 @@ use crate::parser::parse;
 #[test]
 fn test_parse_empty_function() {
     let raw = "fn main() {}";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -32,7 +32,7 @@ fn test_parse_function_with_return() {
         return 1
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -44,7 +44,7 @@ fn test_parse_redundant_semicolon() {
         return 1;
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_err())
 }
@@ -54,7 +54,7 @@ fn test_parse_no_function_context() {
     let raw = "
     let x = 1
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_err())
 }
@@ -72,7 +72,7 @@ fn test_parse_multiple_functions() {
         return y
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -85,7 +85,7 @@ fn test_parse_variable_declaration() {
         return x
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -99,7 +99,7 @@ fn test_parse_variable_reassignment() {
         return x
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -113,7 +113,7 @@ fn test_parse_variable_declaration_added() {
         return x + y
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -125,7 +125,7 @@ fn test_parse_function_with_args() {
         return foo
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -141,7 +141,7 @@ fn test_parse_function_call() {
         foo(2)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -157,7 +157,7 @@ fn test_parse_return_function_call() {
         return fib(2)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -173,7 +173,7 @@ fn test_parse_function_call_multiple_arguments() {
         return 2
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -189,7 +189,7 @@ fn test_parse_nexted_function_call() {
         return 2
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -201,7 +201,7 @@ fn test_parse_basic_ops() {
         return 2 * 5
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -213,7 +213,7 @@ fn test_parse_compound_ops() {
         2 * 5 / 3
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -225,7 +225,7 @@ fn test_parse_compound_ops_with_function_call() {
         return 2 * fib(1) / 3
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -237,7 +237,7 @@ fn test_parse_compound_ops_with_strings() {
         return 2 * \"Hello\"
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -249,7 +249,7 @@ fn test_parse_compound_ops_with_identifier() {
         return 2 * n
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -261,7 +261,7 @@ fn test_parse_compound_ops_with_identifier_first() {
         return n * 2
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -273,7 +273,7 @@ fn test_parse_compound_ops_return() {
         return 2 * n
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -287,7 +287,7 @@ fn test_parse_basic_conditional() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -302,7 +302,7 @@ fn test_parse_basic_conditional_with_multiple_statements() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -319,7 +319,7 @@ fn test_parse_conditional_else_if_branch() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -338,7 +338,7 @@ fn test_parse_conditional_multiple_else_if_branch_branches() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -355,7 +355,7 @@ fn test_parse_conditional_else_branch() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -376,7 +376,7 @@ fn test_parse_conditional_elseif_else_branch() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -389,7 +389,7 @@ fn test_int_array() {
         return arr
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -401,7 +401,7 @@ fn test_string_array() {
         return [\"Foo\", \"Bar\", \"Baz\"]
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -416,7 +416,7 @@ fn test_basic_while_loop() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -431,7 +431,7 @@ fn test_while_loop_boolean_expression() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -448,7 +448,7 @@ fn test_boolean_arithmetic() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -458,16 +458,16 @@ fn test_array_access_in_loop() {
     let raw = "
     fn main() {
         let x = [1, 2, 3, 4, 5]
-    
+
         let i = 0
-    
+
         while i < 5 {
           println(x[i])
           i += 1
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -477,11 +477,11 @@ fn test_array_access_standalone() {
     let raw = "
     fn main() {
         let x = [1, 2, 3, 4, 5]
-    
+
         x[0]
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -496,7 +496,7 @@ fn test_array_access_assignment() {
         return x
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -512,7 +512,7 @@ fn test_array_access_in_if() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -525,7 +525,7 @@ fn test_uninitialized_variables() {
         let y
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -537,7 +537,7 @@ fn test_function_call_math() {
         main(m - 1)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -549,7 +549,7 @@ fn test_function_multiple_args() {
         main(m, n)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -561,7 +561,7 @@ fn test_array_position_assignment() {
         new_arr[i] = 1
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -575,7 +575,7 @@ fn test_typed_declare() {
         let z: bool = false
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok())
 }
@@ -587,7 +587,7 @@ fn test_no_function_args_without_type() {
         return n
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_err())
 }
@@ -599,7 +599,7 @@ fn test_function_with_return_type() {
         return n
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
     assert_eq!(tree.unwrap().func[0].ret_type, Some(Type::Int));
@@ -616,7 +616,7 @@ fn test_booleans_in_function_call() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -636,7 +636,7 @@ fn test_late_initializing_variable() {
         _printf(y)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -652,7 +652,7 @@ fn test_simple_for_loop() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -670,7 +670,7 @@ fn test_nested_for_loop() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -688,7 +688,7 @@ fn test_nested_array() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -701,7 +701,7 @@ fn test_simple_nested_expression() {
         println(x)
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -711,7 +711,7 @@ fn test_continue() {
     let raw = "
     fn main() {
         let arr = [1, 2, 3]
-    
+
         for x in arr {
             if x == 2 {
                 continue
@@ -721,7 +721,7 @@ fn test_continue() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -731,7 +731,7 @@ fn test_break() {
     let raw = "
     fn main() {
         let arr = [1, 2, 3]
-    
+
         for x in arr {
             if x == 2 {
                 break
@@ -741,7 +741,7 @@ fn test_break() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -751,7 +751,7 @@ fn test_complex_nested_expressions() {
     let raw = "
     fn main() {
         let year = 2020
-    
+
         if (year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0) {
             println('Leap year')
         } else {
@@ -759,7 +759,7 @@ fn test_complex_nested_expressions() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -771,7 +771,7 @@ fn test_array_as_argument() {
         println([1, 2, 3])
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -784,7 +784,7 @@ fn test_struct_initialization() {
         first_name: string
         last_name: string
     }
-    
+
     fn main() {
         let foo = new User {
             username: 'foobar'
@@ -793,7 +793,7 @@ fn test_struct_initialization() {
         }
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }
@@ -802,28 +802,28 @@ fn test_struct_initialization() {
 fn test_arithmetic() {
     // These should pass
     let raw = "fn main() {1*1}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_ok());
 
     let raw = "fn main() {2+3*4}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_ok());
 
     let raw = "fn main() {(2+2)*3}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_ok());
 
     // These should fail
     let raw = "fn main() {(22+)+1}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_err());
 
     let raw = "fn main() {1++1}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_err());
 
     let raw = "fn main() {3)+1}";
-    let tree = parse(tokenize(raw), Some(raw.to_string()), raw.into());
+    let tree = parse(tokenize(raw).unwrap(), Some(raw.to_string()), raw.into());
     assert!(tree.is_err());
 }
 
@@ -837,7 +837,7 @@ fn test_array_capacity() {
         let arr3: int[5] = [1, 2, 3, 4, 5]
     }
     ";
-    let tokens = tokenize(raw);
+    let tokens = tokenize(raw).unwrap();
     let tree = parse(tokens, Some(raw.to_string()), "".into());
     assert!(tree.is_ok());
 }


### PR DESCRIPTION
Fixes issues with QBE generator

### Description

Passing string literals directly to the target language fails on assembly-like targets (e.g. QBE) or languages that don't use the same escape sequences. Leaving string syntax to the generator and parsing escape sequences allows to support more backends and also will make escape sequences consistent and non-dependent on the target language.

### Changes proposed in this pull request

- Lexer should understand escape sequences and return a _raw_ string in `TokenKind::Literal(Value::Str(..))`
- Generators need to wrap those strings in their syntax manually

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] ~~Proposed feature/fix is sufficiently documented~~
- [x] Add an entry to the specification
- [ ] The "Unreleased" section in the changelog has been updated, if applicable
- [ ] Rebase this onto QBE branch