### PR TITLE
qbe: Improvements to structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+**Features**
+
+- QBE: Added proper memory alignment for struct fields based on field types ([#61](https://github.com/antimony-lang/antimony/pull/61))
+
 **Fixes**
 
 - Fixed parsing of binary operations in inline function expressions ([#109](https://github.com/antimony-lang/antimony/pull/109))
+- QBE: Fixed struct field access and memory layout for nested structs ([#61](https://github.com/antimony-lang/antimony/pull/61))
 
 **Maintenance**
 

--- a/examples/sandbox.sb
+++ b/examples/sandbox.sb
@@ -9,7 +9,7 @@ struct Rectangle {
     height: int
 }
 
-fn test_nested_field_access() {
+fn main(): int {
     let rect = new Rectangle {
         origin: new Point {
             x: 10
@@ -18,7 +18,9 @@ fn test_nested_field_access() {
         width: 100
         height: 50
     }
-    assert(rect.origin.x == 10)
+    rect.origin.x == 10
     rect.origin.x += 5
-    assert(rect.origin.x == 15)
+    rect.origin.x == 15
+
+    return 0
 }

--- a/examples/sandbox.sb
+++ b/examples/sandbox.sb
@@ -1,11 +1,24 @@
-fn main() {
-    let number = 3
+struct Point {
+    x: int
+    y: int
+}
 
-    while number != 0 {
-        println(number)
+struct Rectangle {
+    origin: Point
+    width: int
+    height: int
+}
 
-        number = number - 1
+fn test_nested_field_access() {
+    let rect = new Rectangle {
+        origin: new Point {
+            x: 10
+            y: 20
+        }
+        width: 100
+        height: 50
     }
-
-    println("LIFTOFF!!!")
+    assert(rect.origin.x == 10)
+    rect.origin.x += 5
+    assert(rect.origin.x == 15)
 }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -139,7 +139,7 @@ impl QbeGenerator {
         offset = self.align_offset(offset, max_align);
 
         // Set the typedef's alignment
-        typedef.align = Some(max_align as u64);
+        typedef.align = Some(max_align);
 
         self.struct_map.insert(
             def.name.clone(),

--- a/tests/structs.sb
+++ b/tests/structs.sb
@@ -8,6 +8,7 @@ fn structs_main() {
     test_method_call()
     test_function_call_with_constructor()
     test_method_with_self_statement()
+    test_nested_field_access()
 }
 
 struct User {
@@ -108,4 +109,29 @@ struct Self_test_struct {
 fn test_method_with_self_statement() {
     let foo = new Self_test_struct { a: 5 }
     foo.bar()
+}
+
+struct Point {
+    x: int
+    y: int
+}
+
+struct Rectangle {
+    origin: Point
+    width: int
+    height: int
+}
+
+fn test_nested_field_access() {
+    let rect = new Rectangle {
+        origin: new Point {
+            x: 10
+            y: 20
+        }
+        width: 100
+        height: 50
+    }
+    assert(rect.origin.x == 10)
+    rect.origin.x += 5
+    assert(rect.origin.x == 15)
 }


### PR DESCRIPTION
### Description

Implements a few cool things for structs in the QBE backend. Now it should be much more usable.
Unfortunately, right now it uses `memcpy` which means now all programs using structs implicitly depend on libc.

Aside: a proper type system would have helped here significantly.

Example (Antimony + C):
```
struct Bar {
	b: int
}
struct Foo {
	a: int
	bar: Bar
}

fn main() {
	let foo = new Foo {
		a: 2
		bar: new Bar {
			b: 12
		}
	}
	check(foo)
	foo.bar.b += 1
	check2(foo)
}
```

```c
#include <assert.h>

struct Bar {
	int b;
};
struct Foo {
	int a;
	struct Bar bar;
};

void check(struct Foo foo)
{
	assert(foo.a == 2);
	assert(foo.bar.b == 12);
}
void check2(struct Foo foo)
{
	assert(foo.a == 2);
	assert(foo.bar.b == 13);
}
```
```
$ sb -t qbe build -o temp.ssa structs.sb
$ qbe -o temp.s temp.ssa
$ cc -o structs temp.s structs.c
```

### ToDo

- [x] Implement nested field access
- [x] Implement nested intialization
- [x] Take alignment into account
- [ ] (unlikely) implement methods
- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable
