### PR TITLE
Short function declaration

### DIFF
--- a/builtin/builtin.ssa
+++ b/builtin/builtin.ssa
@@ -1,0 +1,5 @@
+export function $println(l %str) {
+@start
+        %vd.1 =w call $puts(l %str)
+        ret
+}

--- a/builtin/builtin.ssa
+++ b/builtin/builtin.ssa
@@ -1,5 +1,0 @@
-export function $println(l %str) {
-@start
-        %vd.1 =w call $puts(l %str)
-        ret
-}

--- a/src/generator/c.rs
+++ b/src/generator/c.rs
@@ -92,10 +92,23 @@ pub(super) fn generate_type(t: Either<Variable, Option<Type>>) -> String {
 fn generate_function(func: Function) -> String {
     let mut buf = String::new();
     buf += &format!("{} ", &generate_function_signature(func.clone()));
-    if let Statement::Block { statements, scope } = func.body {
-        buf += &generate_block(statements, scope);
-    }
-
+    // if let Statement::Block { statements, scope } = func.body {
+        // buf += &generate_block(statements, scope);
+    // }
+    let body = match &func.body {
+        #[allow(unused_variables)]
+        super::Statement::Block { statements, scope } => {
+            let expr = &generate_block(statements.clone(), scope.clone());
+            expr.to_string()
+        }
+        _ => {
+            let expr = &generate_statement(func.body);
+            let expr = expr.trim();
+            format!("{{ return {expr} /* Single return */ }}")
+        }
+    }; 
+    buf += &body;
+    buf += "\n";
     buf
 }
 

--- a/src/generator/js.rs
+++ b/src/generator/js.rs
@@ -61,6 +61,7 @@ fn generate_function(func: Function) -> String {
     let mut raw = format!("function {N}({A})", N = func.name, A = arguments);
 
     let body = match &func.body {
+        #[allow(unused_variables)]
         super::Statement::Block { statements, scope } => {
             let expr = &generate_block(func.body, None);
             expr.to_string()
@@ -68,10 +69,11 @@ fn generate_function(func: Function) -> String {
         _ => {
             let expr = &generate_statement(func.body);
             let expr = expr.trim();
-            format!("{{ return {expr} // Single return }}")
+            format!("{{ return {expr} /* Single return */ }}")
 
         }
     }; 
+
     raw.push_str(&body);
     raw += "\n";
     raw

--- a/src/generator/js.rs
+++ b/src/generator/js.rs
@@ -60,7 +60,19 @@ fn generate_function(func: Function) -> String {
 
     let mut raw = format!("function {N}({A})", N = func.name, A = arguments);
 
-    raw += &generate_block(func.body, None);
+    let body = match &func.body {
+        super::Statement::Block { statements, scope } => {
+            let expr = &generate_block(func.body, None);
+            expr.to_string()
+        }
+        _ => {
+            let expr = &generate_statement(func.body);
+            let expr = expr.trim();
+            format!("{{ return {expr} // Single return }}")
+
+        }
+    }; 
+    raw.push_str(&body);
     raw += "\n";
     raw
 }
@@ -115,7 +127,7 @@ fn generate_block(block: Statement, prepend: Option<String>) -> String {
             statements,
             scope: _,
         } => statements,
-        _ => panic!("Block body should be of type Statement::Block"),
+        _ => panic!("Block body should be of type Statement::Block found {:?}", block),
     };
 
     for statement in statements {

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -50,6 +50,11 @@ impl Generator for QbeGenerator {
         // TODO: use `qbe::Module` API instead of writing to the buffer directly
         let mut buf = String::new();
 
+        let raw_builtins =
+            crate::Builtins::get("builtin.ssa").expect("Could not locate builtin functions");
+        buf += std::str::from_utf8(raw_builtins.as_ref())
+            .expect("Unable to interpret builtin functions");
+
         for def in &prog.structs {
             let structure = generator.generate_struct(def)?;
 

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -772,7 +772,7 @@ impl QbeGenerator {
     /// Returns a QBE type for the given AST type
     fn get_type(&self, ty: Type) -> GeneratorResult<qbe::Type> {
         match ty {
-            Type::Any => Err("'any' type is not supported".into()),
+            Type::Any => Ok(qbe::Type::Long),
             Type::Int => Ok(qbe::Type::Word),
             Type::Bool => Ok(qbe::Type::Byte),
             Type::Str => Ok(qbe::Type::Long),

--- a/src/parser/rules.rs
+++ b/src/parser/rules.rs
@@ -159,7 +159,13 @@ impl Parser {
             _ => None,
         };
 
-        let body = self.parse_block()?;
+        let peeked_kind = self.peek()?.kind; 
+        let body = if peeked_kind == TokenKind::CurlyBracesOpen {
+            self.parse_block()?
+        } else {
+            self.next()?;
+            self.parse_statement()?
+        };
 
         Ok(Function {
             name,


### PR DESCRIPTION
In this PR I have implemented the feature that allows us to write shorter functions without having to wrap statements around a block. This works for simple functions that do only 1 thing, like sum two number, or print to the console etc. The syntax looks like this. 

```
fn add(x: int, y: int): int = x + y 
fn println(msg: string) = _print(msg + "\n") <- This won't in c work for now coz the return type is void, its gonna emit return _print(msg + "\n") and c is gonna complain. 
```
For now this code compiles on the following backends:
- [x] JS
- [x] C
- [ ] QBE (Work in progress)
- [ ] LLVM


