### PR TITLE
QBE Structs Overhall

### DIFF
--- a/examples/sandbox.sb
+++ b/examples/sandbox.sb
@@ -9,7 +9,7 @@ struct Rectangle {
     height: int
 }
 
-fn test_nested_field_access() {
+fn main(): int {
     let rect = new Rectangle {
         origin: new Point {
             x: 10
@@ -18,7 +18,9 @@ fn test_nested_field_access() {
         width: 100
         height: 50
     }
-    assert(rect.origin.x == 10)
+    rect.origin.x == 10
     rect.origin.x += 5
-    assert(rect.origin.x == 15)
+    rect.origin.x == 15
+
+    return 0
 }

--- a/examples/sandbox.sb
+++ b/examples/sandbox.sb
@@ -1,11 +1,24 @@
-fn main() {
-    let number = 3
+struct Point {
+    x: int
+    y: int
+}
 
-    while number != 0 {
-        println(number)
+struct Rectangle {
+    origin: Point
+    width: int
+    height: int
+}
 
-        number = number - 1
+fn test_nested_field_access() {
+    let rect = new Rectangle {
+        origin: new Point {
+            x: 10
+            y: 20
+        }
+        width: 100
+        height: 50
     }
-
-    println("LIFTOFF!!!")
+    assert(rect.origin.x == 10)
+    rect.origin.x += 5
+    assert(rect.origin.x == 15)
 }

--- a/src/generator/qbe.rs
+++ b/src/generator/qbe.rs
@@ -139,7 +139,7 @@ impl QbeGenerator {
         offset = self.align_offset(offset, max_align);
 
         // Set the typedef's alignment
-        typedef.align = Some(max_align as u64);
+        typedef.align = Some(max_align);
 
         self.struct_map.insert(
             def.name.clone(),

--- a/tests/structs.sb
+++ b/tests/structs.sb
@@ -8,6 +8,7 @@ fn structs_main() {
     test_method_call()
     test_function_call_with_constructor()
     test_method_with_self_statement()
+    test_nested_field_access()
 }
 
 struct User {
@@ -108,4 +109,29 @@ struct Self_test_struct {
 fn test_method_with_self_statement() {
     let foo = new Self_test_struct { a: 5 }
     foo.bar()
+}
+
+struct Point {
+    x: int
+    y: int
+}
+
+struct Rectangle {
+    origin: Point
+    width: int
+    height: int
+}
+
+fn test_nested_field_access() {
+    let rect = new Rectangle {
+        origin: new Point {
+            x: 10
+            y: 20
+        }
+        width: 100
+        height: 50
+    }
+    assert(rect.origin.x == 10)
+    rect.origin.x += 5
+    assert(rect.origin.x == 15)
 }


### PR DESCRIPTION
Builds upon #61 

Note: Not properly tested, since I'm currently on an arm machine.

## Description

The QBE backend now provides comprehensive support for struct types with proper memory alignment and field access. This implementation handles nested structs, field access, and ensures proper memory layout according to standard alignment rules.

## Features

- Proper struct field alignment
- Nested field access support
- Nested struct initialization
- Memory layout optimization
- Automatic padding calculation

## Memory Layout

Structs are laid out in memory following these rules:
1. Each field is aligned according to its natural alignment requirements:
   - `bool`: 1-byte alignment
   - `halfword`: 2-byte alignment
   - `int`/`word`: 4-byte alignment
   - `long`/`pointer`: 8-byte alignment
2. The struct's total size is padded to maintain its largest field's alignment requirement
3. Nested structs maintain their alignment requirements within parent structs

## Usage Example

```rust
struct Point {
    x: int
    y: int
}

struct Rectangle {
    origin: Point
    width: int
    height: int
}

fn main() {
    let rect = new Rectangle {
        origin: new Point {
            x: 10
            y: 20
        }
        width: 100
        height: 50
    }
    // Fields can be accessed naturally
    rect.origin.x += 5
}
```

### ToDo

- [ ] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable
